### PR TITLE
Issue #3: Fix tideways.so renamed to tideways_xhprof.so

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
   shell: >
     {{ item }}
     chdir={{ workspace }}/{{ tideways_download_folder_name }}
-    creates={{ workspace }}/{{ tideways_download_folder_name }}/modules/tideways.so
+    creates={{ workspace }}/{{ tideways_download_folder_name }}/modules/tideways_xhprof.so
   with_items:
     - phpize
     - ./configure
@@ -49,8 +49,8 @@
 
 - name: Move Tideways module into place.
   shell: >
-    cp {{ workspace }}/{{ tideways_download_folder_name }}/modules/tideways.so {{ php_tideways_module_path }}/tideways.so
-    creates={{ php_tideways_module_path }}/tideways.so
+    cp {{ workspace }}/{{ tideways_download_folder_name }}/modules/tideways_xhprof.so {{ php_tideways_module_path }}/tideways_xhprof.so
+    creates={{ php_tideways_module_path }}/tideways_xhprof.so
   notify: restart webserver
 
 # TODO - Install the Tideways.php file for UI?

--- a/templates/tideways.ini.j2
+++ b/templates/tideways.ini.j2
@@ -1,5 +1,5 @@
 [tideways]
-extension="{{ php_tideways_module_path }}/tideways.so"
+extension="{{ php_tideways_module_path }}/tideways_xhprof.so"
 {% if tideways_api_key %}
 tideways.api_key={{ tideways_api_key }}
 {% else %}

--- a/tests/tideways-test.php
+++ b/tests/tideways-test.php
@@ -9,10 +9,10 @@ $tideways_root_dir = '/usr/share/php';
 $xhprof_root_dir = '/usr/share/php';
 $success = TRUE;
 
-tideways_enable();
-$data = tideways_disable();
+tideways_xhprof_enable();
+$data = tideways_xhprof_disable();
 
-if (isset($data['main()==>tideways_disable'])) {
+if (isset($data['main()==>tideways_xhprof_disable'])) {
   print "Tideways profiling working.\r\n";
 }
 else {


### PR DESCRIPTION
A few notes:

- The ini file is still named `tideways`, even if it maybe should be called `tideways_xhprof` now. By keeping the old name we don't need to do any cleanup though.
- Previously built `tideways.so` will be kept, but not used.