### PR TITLE
Define tideways_extension_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Where Tideways setup files will be downloaded and built.
 
     tideways_download_url: https://github.com/tideways/php-xhprof-extension/archive/master.zip
     tideways_download_folder_name: php-xhprof-extension-master
+    tideways_extension_name: tideways_xhprof.so
 
 The URL from which Tideways will be downloaded.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ workspace: /root
 
 tideways_download_url: https://github.com/tideways/php-xhprof-extension/archive/master.zip
 tideways_download_folder_name: php-xhprof-extension-master
+tideways_extension_name: tideways_xhprof.so
 
 # If you use the Tideways UI, set this variable to your API key. Otherwise the
 # extension can be used along with the XHProf UI to view profiles.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
   command: >
     {{ item }}
     chdir={{ workspace }}/{{ tideways_download_folder_name }}
-    creates={{ workspace }}/{{ tideways_download_folder_name }}/modules/tideways_xhprof.so
+    creates={{ workspace }}/{{ tideways_download_folder_name }}/modules/{{ tideways_extension_name }}
   with_items:
     - phpize
     - ./configure
@@ -49,9 +49,9 @@
 
 - name: Move Tideways module into place.
   command: >
-    cp {{ workspace }}/{{ tideways_download_folder_name }}/modules/tideways_xhprof.so
-    {{ php_tideways_module_path }}/tideways_xhprof.so
-    creates={{ php_tideways_module_path }}/tideways_xhprof.so
+    cp {{ workspace }}/{{ tideways_download_folder_name }}/modules/{{ tideways_extension_name }}
+    {{ php_tideways_module_path }}/{{ tideways_extension_name }}
+    creates={{ php_tideways_module_path }}/{{ tideways_extension_name }}
   notify: restart webserver
 
 # TODO - Install the Tideways.php file for UI?

--- a/templates/tideways.ini.j2
+++ b/templates/tideways.ini.j2
@@ -1,5 +1,5 @@
 [tideways]
-extension="{{ php_tideways_module_path }}/tideways_xhprof.so"
+extension="{{ php_tideways_module_path }}/{{ tideways_extension_name }}"
 {% if tideways_api_key %}
 tideways.api_key={{ tideways_api_key }}
 {% else %}


### PR DESCRIPTION
By default builded module is named tideways_xhprof.so
but with 4.x it is named tideways.so